### PR TITLE
Increase test coverage for replacing ops based on gas price

### DIFF
--- a/tests/bundle/test_bundle.py
+++ b/tests/bundle/test_bundle.py
@@ -45,7 +45,7 @@ def test_bundle_replace_with_only_priority_fee_change(w3):
 
     assert_rpc_error(lower_fee_op.send(), "", RPCErrorCode.INVALID_FIELDS)
     assert dump_mempool() == [mid_fee_op]
-    
+
     assert_rpc_error(higher_fee_op.send(), "", RPCErrorCode.INVALID_FIELDS)
     assert dump_mempool() == [mid_fee_op]
 
@@ -61,7 +61,8 @@ def test_bundle_replace_with_equally_increasing_max_fee(w3):
         maxPriorityFeePerGas=hex(LOWER_MAX_PRIORITY_FEE_PER_GAS),
     )
 
-    mid_max_fee_per_gas = int(lower_fee_op.maxFeePerGas, 16)+(MID_MAX_PRIORITY_FEE_PER_GAS-LOWER_MAX_PRIORITY_FEE_PER_GAS)
+    mid_max_fee_per_gas = (int(lower_fee_op.maxFeePerGas, 16)
+    + (MID_MAX_PRIORITY_FEE_PER_GAS-LOWER_MAX_PRIORITY_FEE_PER_GAS))
     mid_fee_op = UserOperation(
         sender=wallet.address,
         nonce="0x1",
@@ -70,7 +71,8 @@ def test_bundle_replace_with_equally_increasing_max_fee(w3):
         maxFeePerGas=hex(mid_max_fee_per_gas)
     )
 
-    higher_max_fee_per_gas = int(mid_fee_op.maxFeePerGas, 16)+(HIGHER_MAX_PRIORITY_FEE_PER_GAS-MID_MAX_PRIORITY_FEE_PER_GAS)
+    higher_max_fee_per_gas = (int(mid_fee_op.maxFeePerGas, 16)
+    + (HIGHER_MAX_PRIORITY_FEE_PER_GAS-MID_MAX_PRIORITY_FEE_PER_GAS))
     higher_fee_op = UserOperation(
         sender=wallet.address,
         nonce="0x1",

--- a/tests/bundle/test_bundle.py
+++ b/tests/bundle/test_bundle.py
@@ -1,4 +1,3 @@
-import math
 import pytest
 
 from tests.types import UserOperation, RPCErrorCode, RPCRequest
@@ -17,7 +16,7 @@ DEFAULT_MAX_FEE_PER_GAS = 5*10**9
 MIN_PRICE_BUMP = 10
 
 def bump_fee_by(fee, factor):
-    return math.ceil((fee*(100+factor)/100))
+    return round((fee*(100+factor)/100))
 
 
 @pytest.mark.parametrize("mode", ["manual"], ids=[""])

--- a/tests/bundle/test_bundle.py
+++ b/tests/bundle/test_bundle.py
@@ -105,7 +105,7 @@ def test_bundle_replace_with_same_fee(w3):
 
 @pytest.mark.parametrize("mode", ["manual"], ids=[""])
 @pytest.mark.usefixtures("clear_state", "set_bundling_mode")
-def test_bundle_replace_with_fee_reduction(w3):
+def test_bundle_replace_with_less_fee(w3):
     wallet = deploy_wallet_contract(w3)
     calldata = wallet.encodeABI(fn_name="setState", args=[1])
     new_op = UserOperation(

--- a/tests/bundle/test_bundle.py
+++ b/tests/bundle/test_bundle.py
@@ -15,8 +15,8 @@ DEFAULT_MAX_PRIORITY_FEE_PER_GAS = 10**9
 DEFAULT_MAX_FEE_PER_GAS = 5*10**9
 MIN_PRICE_BUMP = 10
 
-def bump_fee_by(fee, percentage):
-    return round(fee*(100+percentage)/100)
+def bump_fee_by(fee, factor):
+    return round(fee*(100+factor)/100)
 
 
 @pytest.mark.parametrize("mode", ["manual"], ids=[""])

--- a/tests/bundle/test_bundle.py
+++ b/tests/bundle/test_bundle.py
@@ -1,4 +1,5 @@
 import pytest
+import math
 
 from tests.types import UserOperation, RPCErrorCode, RPCRequest
 from tests.utils import (
@@ -16,7 +17,7 @@ DEFAULT_MAX_FEE_PER_GAS = 5*10**9
 MIN_PRICE_BUMP = 10
 
 def bump_fee_by(fee, factor):
-    return round(fee*(100+factor)/100)
+    return math.ceil((fee*(100+factor)/100))
 
 
 @pytest.mark.parametrize("mode", ["manual"], ids=[""])

--- a/tests/bundle/test_bundle.py
+++ b/tests/bundle/test_bundle.py
@@ -1,5 +1,5 @@
-import pytest
 import math
+import pytest
 
 from tests.types import UserOperation, RPCErrorCode, RPCRequest
 from tests.utils import (


### PR DESCRIPTION
Propose a fix for the two test cases in `tests/bundle/test_bundle.py`.

1. `test_bundle_replace_by_fee` currently doesn't take into account an equally increased `maxFeePerGas`.
2. `test_bundle` sends multiple ops to the bundler from an unstaked account.

As is, both test cases don't comply with the sanity check for pending userOps in the mempool: https://github.com/eth-infinitism/account-abstraction/blob/c2a541bb8c29cbb583c5ea1f3eefdd99be40654c/eip/EIPS/eip-4337.md?plain=1#L276