### PR TITLE
Add test case for a UserOperation close to expiry

### DIFF
--- a/tests/contracts/SimpleWallet.sol
+++ b/tests/contracts/SimpleWallet.sol
@@ -39,6 +39,12 @@ contract SimpleWallet is IAccount {
         }
         bytes2 sig = bytes2(userOp.signature);
         require(sig != 0xdead, "testWallet: dead signature");
-        return sig == 0xdeaf ? 1 : 0;
+        if (sig == 0xdeaf) return 1;
+        if (userOp.signature.length == 64) {
+            (uint48 validUntil, uint48 validAfter) = abi.decode(userOp.signature,(uint48, uint48));
+            return (uint256(validUntil) << 160) | (uint256(validAfter) << (160 + 48));
+        }
+
+        return 0;
     }
 }

--- a/tests/contracts/SimpleWallet.sol
+++ b/tests/contracts/SimpleWallet.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.12;
 
 import "@account-abstraction/contracts/interfaces/IAccount.sol";
 import "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import "@account-abstraction/contracts/core/Helpers.sol";
 import "./State.sol";
 
 contract SimpleWallet is IAccount {
@@ -42,7 +43,7 @@ contract SimpleWallet is IAccount {
         if (sig == 0xdeaf) return 1;
         if (userOp.signature.length == 64) {
             (uint48 validUntil, uint48 validAfter) = abi.decode(userOp.signature,(uint48, uint48));
-            return (uint256(validUntil) << 160) | (uint256(validAfter) << (160 + 48));
+            return _packValidationData(false, validUntil, validAfter);
         }
 
         return 0;

--- a/tests/rpc/conftest.py
+++ b/tests/rpc/conftest.py
@@ -29,7 +29,7 @@ def expires_shortly_userop(wallet_contract):
     return UserOperation(
         sender=wallet_contract.address,
         callData=wallet_contract.encodeABI(fn_name="setState", args=[1111111]),
-        signature=Web3.toHex(encode_abi(['uint48', 'uint48'], [int(time.time())+30, 0])),
+        signature=Web3.toHex(encode_abi(['uint48', 'uint48'], [int(time.time())+29, 0])),
     )
 
 @pytest.fixture(scope="session")

--- a/tests/rpc/conftest.py
+++ b/tests/rpc/conftest.py
@@ -25,7 +25,7 @@ def invalid_sig_userop(wallet_contract):
     )
 
 @pytest.fixture
-def expire_shortly_userop(wallet_contract):
+def expires_shortly_userop(wallet_contract):
     return UserOperation(
         sender=wallet_contract.address,
         callData=wallet_contract.encodeABI(fn_name="setState", args=[1111111]),

--- a/tests/rpc/conftest.py
+++ b/tests/rpc/conftest.py
@@ -29,7 +29,7 @@ def expires_shortly_userop(wallet_contract):
     return UserOperation(
         sender=wallet_contract.address,
         callData=wallet_contract.encodeABI(fn_name="setState", args=[1111111]),
-        signature=Web3.toHex(encode_abi(['uint48', 'uint48'], [int(time.time())+29, 0])),
+        signature=Web3.toHex(encode_abi(['uint48', 'uint48'], [int(time.time())+30, 0])),
     )
 
 @pytest.fixture(scope="session")

--- a/tests/rpc/conftest.py
+++ b/tests/rpc/conftest.py
@@ -1,7 +1,10 @@
 import json
 import os
 
+import time
 import pytest
+from web3 import Web3
+from eth_abi import encode_abi
 from tests.types import UserOperation
 
 
@@ -19,6 +22,14 @@ def invalid_sig_userop(wallet_contract):
         sender=wallet_contract.address,
         callData=wallet_contract.encodeABI(fn_name="setState", args=[1111111]),
         signature="0xdeaf",
+    )
+
+@pytest.fixture
+def expire_shortly_userop(wallet_contract):
+    return UserOperation(
+        sender=wallet_contract.address,
+        callData=wallet_contract.encodeABI(fn_name="setState", args=[1111111]),
+        signature=Web3.toHex(encode_abi(['uint48', 'uint48'], [int(time.time())+30, 0])),
     )
 
 @pytest.fixture(scope="session")

--- a/tests/rpc/test_eth_sendUserOperation.py
+++ b/tests/rpc/test_eth_sendUserOperation.py
@@ -38,7 +38,7 @@ def test_eth_sendUserOperation_invalid_signature(invalid_sig_userop):
         invalid_sig_userop.send(), "Invalid UserOp signature or paymaster signature", RPCErrorCode.INVALID_SIGNATURE
     )
 
-def test_eth_sendUserOperation_expires_shortly(expire_shortly_userop):
+def test_eth_sendUserOperation_expires_shortly(expires_shortly_userop):
     assert_rpc_error(
-        expire_shortly_userop.send(), "expires too soon", RPCErrorCode.SHORT_DEADLINE
+        expires_shortly_userop.send(), "expires too soon", RPCErrorCode.SHORT_DEADLINE
     )

--- a/tests/rpc/test_eth_sendUserOperation.py
+++ b/tests/rpc/test_eth_sendUserOperation.py
@@ -37,3 +37,8 @@ def test_eth_sendUserOperation_invalid_signature(invalid_sig_userop):
     assert_rpc_error(
         invalid_sig_userop.send(), "Invalid UserOp signature or paymaster signature", RPCErrorCode.INVALID_SIGNATURE
     )
+
+def test_eth_sendUserOperation_expires_shortly(expire_shortly_userop):
+    assert_rpc_error(
+        expire_shortly_userop.send(), "expires too soon", RPCErrorCode.SHORT_DEADLINE
+    )


### PR DESCRIPTION
No test case currently exists for when a bundler receives a UserOperation within 30 seconds of reaching its `validUntil` deadline.