### PR TITLE
Add case for unstaked sender accessing associated storage with initCode

### DIFF
--- a/tests/bundle/test_storage_rules.py
+++ b/tests/bundle/test_storage_rules.py
@@ -6,6 +6,7 @@ from tests.types import UserOperation, RPCErrorCode
 from tests.utils import (
     assert_rpc_error,
     deploy_wallet_contract,
+    deploy_state_contract,
     deploy_contract,
     get_sender_address,
     deploy_and_deposit,
@@ -52,9 +53,10 @@ def build_userop_for_paymaster(w3, _entrypoint_contract, paymaster_contract, rul
     return UserOperation(sender=wallet.address, paymasterAndData=paymaster_and_data)
 
 
-def build_userop_for_sender(_w3, _entrypoint_contract, rules_account_contract, rule):
+def build_userop_for_sender(w3, _entrypoint_contract, rules_account_contract, rule):
+    callData = deploy_state_contract(w3).address
     signature = "0x" + rule.encode().hex()
-    return UserOperation(sender=rules_account_contract.address, signature=signature)
+    return UserOperation(sender=rules_account_contract.address, callData=callData, signature=signature)
 
 
 def build_userop_for_factory(w3, entrypoint_contract, factory_contract, rule):
@@ -261,6 +263,13 @@ cases = [
         UNSTAKED,
         SENDER,
         build_userop_for_sender,
+        assert_ok,
+    ),
+    StorageTestCase(
+        "account_reference_storage_init_code",
+        UNSTAKED,
+        SENDER,
+        with_initcode(build_userop_for_sender),
         assert_ok,
     ),
     StorageTestCase(

--- a/tests/bundle/test_storage_rules.py
+++ b/tests/bundle/test_storage_rules.py
@@ -270,7 +270,7 @@ cases = [
         UNSTAKED,
         SENDER,
         with_initcode(build_userop_for_sender),
-        assert_ok,
+        assert_error,
     ),
     StorageTestCase(
         "account_reference_storage_struct",

--- a/tests/bundle/test_storage_rules.py
+++ b/tests/bundle/test_storage_rules.py
@@ -54,9 +54,9 @@ def build_userop_for_paymaster(w3, _entrypoint_contract, paymaster_contract, rul
 
 
 def build_userop_for_sender(w3, _entrypoint_contract, rules_account_contract, rule):
-    callData = deploy_state_contract(w3).address
+    call_data = deploy_state_contract(w3).address
     signature = "0x" + rule.encode().hex()
-    return UserOperation(sender=rules_account_contract.address, callData=callData, signature=signature)
+    return UserOperation(sender=rules_account_contract.address, callData=call_data, signature=signature)
 
 
 def build_userop_for_factory(w3, entrypoint_contract, factory_contract, rule):

--- a/tests/contracts/SimpleWallet.sol
+++ b/tests/contracts/SimpleWallet.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.12;
 
 import "@account-abstraction/contracts/interfaces/IAccount.sol";
 import "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import "./State.sol";
 
 contract SimpleWallet is IAccount {
 
@@ -29,6 +30,10 @@ contract SimpleWallet is IAccount {
 
     function validateUserOp(UserOperation calldata userOp, bytes32, uint256 missingWalletFunds)
     external override returns (uint256 validationData) {
+        if (userOp.callData.length == 20) {
+            State(address(bytes20(userOp.callData))).getState(address(this));
+        }
+
         if (missingWalletFunds>0) {
             msg.sender.call{value:missingWalletFunds}("");
         }

--- a/tests/contracts/State.sol
+++ b/tests/contracts/State.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.12;
+
+contract State {
+    mapping(address => uint) state;
+
+    function getState(address addr) public returns (uint) {
+        return state[addr];
+    }
+}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -72,6 +72,9 @@ def deploy_wallet_contract(w3):
         w3, "SimpleWallet", ctrparams=[CommandLineArgs.entrypoint], value=2 * 10**18
     )
 
+def deploy_state_contract(w3):
+    return deploy_contract(w3, "State")
+
 
 def userop_hash(helper_contract, userop):
     payload = (


### PR DESCRIPTION
No test case currently exits for when an unstaked sender accesses associated storage in its first transaction (i.e. `initCode.length > 0 && op.nonce == 0`).

~~My current assumption is that this case should be ok.~~
EDIT: The correct behaviour is for bundlers to reject these userOps.