### PR TITLE
Allow associated storage when using a staked factory

### DIFF
--- a/tests/bundle/test_storage_rules.py
+++ b/tests/bundle/test_storage_rules.py
@@ -145,7 +145,7 @@ cases = [
         UNSTAKED,
         PAYMASTER,
         with_initcode(build_userop_for_paymaster, deploy_staked_factory),
-        assert_ok,
+        assert_error,
     ),
     StorageTestCase(
         "context", UNSTAKED, PAYMASTER, build_userop_for_paymaster, assert_error

--- a/tests/bundle/test_storage_rules.py
+++ b/tests/bundle/test_storage_rules.py
@@ -24,14 +24,22 @@ def assert_ok(response):
 def assert_error(response):
     assert_rpc_error(response, response.message, RPCErrorCode.BANNED_OPCODE)
 
-
-def with_initcode(build_userop_func):
-    def _with_initcode(w3, entrypoint_contract, contract, rule):
-        factory_contract = deploy_contract(
+def deploy_unstaked_factory(w3, entrypoint_contract):
+    return deploy_contract(
             w3,
             "TestRulesFactory",
             ctrparams=[entrypoint_contract.address],
         )
+
+def deploy_staked_factory(w3, entrypoint_contract):
+    return deploy_and_deposit(
+        w3, entrypoint_contract, "TestRulesFactory", True
+    )
+
+
+def with_initcode(build_userop_func, deploy_factory_func = deploy_unstaked_factory):
+    def _with_initcode(w3, entrypoint_contract, contract, rule):
+        factory_contract = deploy_factory_func(w3, entrypoint_contract)
         userop = build_userop_func(w3, entrypoint_contract, contract, rule)
         initcode = (
             factory_contract.address
@@ -129,6 +137,13 @@ cases = [
         PAYMASTER,
         with_initcode(build_userop_for_paymaster),
         assert_error,
+    ),
+    StorageTestCase(
+        "account_reference_storage_init_code",
+        UNSTAKED,
+        PAYMASTER,
+        with_initcode(build_userop_for_paymaster, deploy_staked_factory),
+        assert_ok,
     ),
     StorageTestCase(
         "context", UNSTAKED, PAYMASTER, build_userop_for_paymaster, assert_error
@@ -271,6 +286,13 @@ cases = [
         SENDER,
         with_initcode(build_userop_for_sender),
         assert_error,
+    ),
+    StorageTestCase(
+        "account_reference_storage_init_code",
+        UNSTAKED,
+        SENDER,
+        with_initcode(build_userop_for_sender, deploy_staked_factory),
+        assert_ok,
     ),
     StorageTestCase(
         "account_reference_storage_struct",


### PR DESCRIPTION
This PR adds two new test cases to reflect recent changes which allow entities to access associated storage if the userOp creates a new account using a staked factory.

From the latest EIP changes:
> If the UserOp doesn't create a new account (that is initCode is empty), or the UserOp creates a new account using a
  staked `factory` contract, then the entity may also use storage associated with the sender