### PR TITLE
increase default maxFeePerGas

### DIFF
--- a/tests/types.py
+++ b/tests/types.py
@@ -39,7 +39,7 @@ class UserOperation:
     callGasLimit: HexStr = hex(3 * 10**5)
     verificationGasLimit: HexStr = hex(10**6)
     preVerificationGas: HexStr = hex(3 * 10**5)
-    maxFeePerGas: HexStr = hex(2 * 10**9)
+    maxFeePerGas: HexStr = hex(4 * 10**9)
     maxPriorityFeePerGas: HexStr = hex(1 * 10**9)
     paymasterAndData: HexStr = "0x"
     signature: HexStr = "0x"


### PR DESCRIPTION
this is only the default, for tests unrelated to gas checks. separately, should add tests that verify proper use of maxFeePerGas (currently, this affects voltaire bundler)