### PR TITLE
increase default maxPriorityFeePerGas,

### DIFF
--- a/tests/types.py
+++ b/tests/types.py
@@ -40,7 +40,7 @@ class UserOperation:
     verificationGasLimit: HexStr = hex(10**6)
     preVerificationGas: HexStr = hex(3 * 10**5)
     maxFeePerGas: HexStr = hex(4 * 10**9)
-    maxPriorityFeePerGas: HexStr = hex(1 * 10**9)
+    maxPriorityFeePerGas: HexStr = hex(3 * 10**9)
     paymasterAndData: HexStr = "0x"
     signature: HexStr = "0x"
 


### PR DESCRIPTION
this is only the default, for tests unrelated to gas checks. separately, should add tests that verify proper use of maxFeePerGas/maxPriorityFeePerGas
(currently, this affects voltaire bundler)