### PR TITLE
added test for STO-033 global read

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,6 @@ jobs:
           name: "deploy entry point"
           working_directory: "./bundler"
           command: yarn hardhat-deploy --network localhost
-          background: true
       - run:
           name: "run bundler"
           working_directory: "./bundler"
@@ -81,7 +80,7 @@ jobs:
           working_directory: "./bundler"
           shell: /bin/sh
           command: |
-            wget --post-data="{\"method\": \"eth_supportedEntryPoints\"}" --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 10 http://localhost:3000/rpc
+            wget --post-data="{\"method\": \"eth_supportedEntryPoints\"}" --retry-connrefused --waitretry=2 --timeout=60 --tries=30 http://localhost:3000/rpc
       - run:
           name: "pytest"
           command: "pdm run test"

--- a/tests/bundle/test_storage_rules.py
+++ b/tests/bundle/test_storage_rules.py
@@ -169,7 +169,7 @@ cases = [
     ),
     StorageTestCase(
         "STO-032",
-        "external_storage",
+        "external_storage_read",
         UNSTAKED,
         PAYMASTER,
         build_userop_for_paymaster,
@@ -220,6 +220,14 @@ cases = [
         assert_ok,
     ),
     StorageTestCase(
+        "STO-033",
+        "reference_storage_struct",
+        STAKED,
+        PAYMASTER,
+        build_userop_for_paymaster,
+        assert_ok,
+    ),
+    StorageTestCase(
         "STO-010",
         "account_storage",
         STAKED,
@@ -255,12 +263,20 @@ cases = [
         "EREP-050", "context", STAKED, PAYMASTER, build_userop_for_paymaster, assert_ok
     ),
     StorageTestCase(
-        "STO-031",
-        "external_storage",
+        "STO-033",
+        "external_storage_write",
         STAKED,
         PAYMASTER,
         build_userop_for_paymaster,
         assert_error,
+    ),
+    StorageTestCase(
+        "STO-033",
+        "external_storage_read",
+        STAKED,
+        PAYMASTER,
+        build_userop_for_paymaster,
+        assert_ok,
     ),
     StorageTestCase(
         "OP-020",
@@ -327,7 +343,7 @@ cases = [
     ),
     StorageTestCase(
         "STO-000",
-        "external_storage",
+        "external_storage_read",
         UNSTAKED,
         FACTORY,
         build_userop_for_factory,
@@ -461,12 +477,20 @@ cases = [
         assert_ok,
     ),
     StorageTestCase(
-        "STO-000",
-        "external_storage",
+        "STO-033",
+        "external_storage_write",
         STAKED,
         FACTORY,
         build_userop_for_factory,
         assert_error,
+    ),
+    StorageTestCase(
+        "STO-033",
+        "external_storage_read",
+        STAKED,
+        FACTORY,
+        build_userop_for_factory,
+        assert_ok,
     ),
     StorageTestCase(
         "OP-020",
@@ -538,7 +562,7 @@ cases = [
     ),
     StorageTestCase(
         "STO-000",
-        "external_storage",
+        "external_storage_read",
         UNSTAKED,
         SENDER,
         build_userop_for_sender,
@@ -590,12 +614,20 @@ cases = [
         assert_error,
     ),
     StorageTestCase(
-        "STO-000",
-        "external_storage",
+        "STO-033",
+        "external_storage_write",
         STAKED,
         SENDER,
         build_userop_for_sender,
         assert_error,
+    ),
+    StorageTestCase(
+        "STO-033",
+        "external_storage_read",
+        STAKED,
+        SENDER,
+        build_userop_for_sender,
+        assert_ok,
     ),
     StorageTestCase(
         "OP-011",

--- a/tests/contracts/TestCoin.sol
+++ b/tests/contracts/TestCoin.sol
@@ -11,8 +11,8 @@ contract TestCoin {
     }
     mapping(address=>Struct) public structInfo;
 
-    function getInfo(address addr) public returns (Struct memory) {
-        return structInfo[addr];
+    function setStructMember(address addr) public returns (uint){
+        return structInfo[addr].c = 3;
     }
 
     function balanceOf(address addr) public returns (uint) {

--- a/tests/contracts/ValidationRules.sol
+++ b/tests/contracts/ValidationRules.sol
@@ -140,15 +140,16 @@ library ValidationRules {
 
         else if (eq(rule, "no_storage")) return 0;
         else if (eq(rule, "storage")) return self.state();
-        else if (eq(rule, "reference_storage")) return coin.balanceOf(address (this));
-        else if (eq(rule, "reference_storage_struct")) return coin.getInfo(address(this)).c;
+        else if (eq(rule, "reference_storage")) return coin.mint(address (this));
+        else if (eq(rule, "reference_storage_struct")) return coin.setStructMember(address(this));
         else if (eq(rule, "account_storage")) return account.state();
 
         else if (eq(rule, "account_reference_storage")) return coin.balanceOf(address(account));
 
-        else if (eq(rule, "account_reference_storage_struct")) return coin.getInfo(address(account)).c;
+        else if (eq(rule, "account_reference_storage_struct")) return coin.setStructMember(address(account));
         else if (eq(rule, "account_reference_storage_init_code")) return coin.balanceOf(address(account));
-        else if (eq(rule, "external_storage")) return coin.balanceOf(address(0xdeadcafe));
+        else if (eq(rule, "external_storage_read")) return coin.balanceOf(address(0xdeadcafe));
+        else if (eq(rule, "external_storage_write")) return coin.mint(address(0xdeadcafe));
         else if (eq(rule, "entryPoint_call_balanceOf")) return self.entryPoint().balanceOf(address(account));
         else if (eq(rule, "eth_value_transfer_forbidden")) return coin.receiveValue{value: 666}();
         else if (eq(rule, "eth_value_transfer_entryPoint")) {


### PR DESCRIPTION
NOTE: changed the "referenced storage"  to write operations (since read is now allowed even on non-associated cells)
using "mint" instead of "balanceOf"
changing "getInfo(addr)" to "setStructMember(addr)"