### PR TITLE
use INVALID_PARAMS_CODE instead of METHOD_NOT_FOUND

### DIFF
--- a/tests/single/rpc/test_eth_getUserOperationByHash.py
+++ b/tests/single/rpc/test_eth_getUserOperationByHash.py
@@ -1,7 +1,7 @@
 import pytest
 from jsonschema import validate, Validator
 from tests.types import RPCRequest, CommandLineArgs, UserOperation
-from tests.utils import userop_hash, assert_rpc_error
+from tests.utils import userop_hash, assert_rpc_code
 
 
 @pytest.mark.usefixtures("execute_user_operation")
@@ -25,4 +25,4 @@ def test_eth_getUserOperationByHash(helper_contract, userop, schema):
 
 def test_eth_getUserOperationByHash_error():
     response = RPCRequest(method="eth_getUserOperationByHash", params=[""]).send()
-    assert_rpc_error(response, "Missing/invalid userOpHash", -32601)
+    assert_rpc_code(response, -32602)

--- a/tests/single/rpc/test_eth_getUserOperationReceipt.py
+++ b/tests/single/rpc/test_eth_getUserOperationReceipt.py
@@ -2,7 +2,7 @@ import pytest
 from jsonschema import validate, Validator
 
 from tests.types import RPCRequest
-from tests.utils import userop_hash, assert_rpc_error
+from tests.utils import userop_hash, assert_rpc_code
 
 
 @pytest.mark.usefixtures("execute_user_operation")
@@ -23,4 +23,4 @@ def test_eth_getUserOperationReceipt(helper_contract, userop, w3, schema):
 
 def test_eth_getUserOperationReceipt_error():
     response = RPCRequest(method="eth_getUserOperationReceipt", params=[""]).send()
-    assert_rpc_error(response, "Missing/invalid userOpHash", -32601)
+    assert_rpc_code(response, -32602)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -119,6 +119,13 @@ def assert_rpc_error(response, message, code):
         raise Exception(f"expected error object, got:\n{response}") from exc
 
 
+def assert_rpc_code(response, code):
+    try:
+        assert response.code == code
+    except AttributeError as exc:
+        raise Exception(f"expected error object, got:\n{response}") from exc
+
+
 def get_sender_address(w3, initcode):
     helper = deploy_contract(w3, "Helper")
     return helper.functions.getSenderAddress(CommandLineArgs.entrypoint, initcode).call(


### PR DESCRIPTION
Splitting out part of #50 

- Change error code from `METHOD_NOT_FOUND` (-32601) to `INVALID_PARAMS_CODE` (-32602)
- Associated reference bundler change: https://github.com/eth-infinitism/bundler/pull/176

