### PR TITLE
feat(compliance): remove remote pull

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires = ["pdm-pep517>=1.0.0"]
 build-backend = "pdm.pep517.api"
 
 [tool.pdm.scripts]
-update-deps = {shell = "git submodule update --remote --init --recursive && cd @account-abstraction && yarn && yarn compile &&  cd ../spec && yarn && yarn build"}
+update-deps = {shell = "git submodule update --init --recursive && cd @account-abstraction && yarn && yarn compile &&  cd ../spec && yarn && yarn build"}
 test = "pytest --tb=short -rA -W ignore::DeprecationWarning --url http://localhost:3000/rpc --entry-point 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 --ethereum-node http://127.0.0.1:8545/ tests/single"
 p2ptest = "pytest --tb=short -rA -W ignore::DeprecationWarning --url http://localhost:3000/rpc --entry-point 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789 --ethereum-node http://127.0.0.1:8545/ tests/p2p"
 lint = "pylint tests"


### PR DESCRIPTION
Right now, many of the spec tests will fail if the `update-deps` function is called due to the update to the 0.7 entrypoint in the account abstraction repository.

We can remove this remote pull so that git will only pull the commit which is linked to the spec tests repository