### PR TITLE
fix(bundle): remove mempool check in multi-op tests

### DIFF
--- a/tests/single/bundle/test_bundle.py
+++ b/tests/single/bundle/test_bundle.py
@@ -252,8 +252,6 @@ def test_max_allowed_ops_unstaked_sender(w3, helper_contract):
             mempool = dump_mempool()
             assert mempool == wallet_ops[:-1]
     send_bundle_now()
-    mempool = dump_mempool()
-    assert mempool == wallet_ops[1:-1]
     ophash = userop_hash(helper_contract, wallet_ops[0])
     response = RPCRequest(
         method="eth_getUserOperationReceipt",
@@ -277,8 +275,6 @@ def test_max_allowed_ops_staked_sender(w3, entrypoint_contract, helper_contract)
         assert dump_mempool() == wallet_ops[: i + 1]
     assert dump_mempool() == wallet_ops
     send_bundle_now()
-    mempool = dump_mempool()
-    assert mempool == wallet_ops[1:]
     ophash = userop_hash(helper_contract, wallet_ops[0])
     response = RPCRequest(
         method="eth_getUserOperationReceipt",


### PR DESCRIPTION
According to ERC-7562 a bundler can decide to include multiple UOs from the same sender in a single bundle. This test assumes that only one UO was included in the bundle. This PR removes this check.