### PR TITLE
fix(paymaster): fix paymaster deposit test

### DIFF
--- a/tests/single/bundle/test_paymaster.py
+++ b/tests/single/bundle/test_paymaster.py
@@ -7,11 +7,12 @@ from tests.utils import (
     assert_ok,
     assert_rpc_error,
     deploy_wallet_contract,
-    deploy_contract, get_userop_verification_max_cost,
+    deploy_contract, get_userop_max_cost,
 )
 
 
 # EREP-010: paymaster should have deposit to cover all userops in mempool
+@pytest.mark.usefixtures("manual_bundling_mode")
 def test_paymaster_deposit(
         w3, entrypoint_contract, paymaster_contract
 ):
@@ -32,7 +33,7 @@ def test_paymaster_deposit(
             paymasterData=to_hex(text="nothing"))
         userops.append(userop)
 
-    sums = [get_userop_verification_max_cost(userop) for userop in userops]
+    sums = [get_userop_max_cost(userop) for userop in userops]
     total_cost = sum(sums)
 
     # deposit enough just below the total cost

--- a/tests/single/bundle/test_paymaster.py
+++ b/tests/single/bundle/test_paymaster.py
@@ -28,7 +28,7 @@ def test_paymaster_deposit(
         userop = UserOperation(
             sender=sender,
             paymaster=paymaster.address,
-            paymasterVerificationGasLimit=50000,
+            paymasterVerificationGasLimit=to_hex(50000),
             paymasterData=to_hex(text="nothing"))
         userops.append(userop)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -275,7 +275,7 @@ def sum_hex(*args):
 
 def get_userop_max_cost(user_op):
     return sum_hex(user_op.preVerificationGas,
-                user_op.verificationGasLimit,
-                user_op.callGasLimit,
-                user_op.paymasterVerificationGasLimit,
-                user_op.paymasterPostOpGasLimit) * to_number(user_op.maxFeePerGas)
+                   user_op.verificationGasLimit,
+                   user_op.callGasLimit,
+                   user_op.paymasterVerificationGasLimit,
+                   user_op.paymasterPostOpGasLimit) * to_number(user_op.maxFeePerGas)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -274,8 +274,8 @@ def sum_hex(*args):
     return sum(to_number(i) for i in args if i is not None)
 
 def get_userop_max_cost(user_op):
-        return sum_hex(user_op.preVerificationGas,
-                   user_op.verificationGasLimit,
-                   user_op.callGasLimit,
-                   user_op.paymasterVerificationGasLimit,
-                   user_op.paymasterPostOpGasLimit) * to_number(user_op.maxFeePerGas)
+    return sum_hex(user_op.preVerificationGas,
+                user_op.verificationGasLimit,
+                user_op.callGasLimit,
+                user_op.paymasterVerificationGasLimit,
+                user_op.paymasterPostOpGasLimit) * to_number(user_op.maxFeePerGas)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -273,8 +273,9 @@ def to_number(num_or_hex):
 def sum_hex(*args):
     return sum(to_number(i) for i in args if i is not None)
 
-
-def get_userop_verification_max_cost(user_op):
-    return sum_hex(user_op.preVerificationGas,
+def get_userop_max_cost(user_op):
+        return sum_hex(user_op.preVerificationGas,
                    user_op.verificationGasLimit,
-                   user_op.paymasterVerificationGasLimit) * to_number(user_op.maxFeePerGas)
+                   user_op.callGasLimit,
+                   user_op.paymasterVerificationGasLimit,
+                   user_op.paymasterPostOpGasLimit) * to_number(user_op.maxFeePerGas)


### PR DESCRIPTION
- Add a `to_hex` around VGL for consistency with the rest of the test suite.
- Modify to use `get_userop_max_cost` instead of `get_userop_verification_max_cost` as the paymaster is responsible for paying for the entirety of the gas, not just verification.