### PR TITLE
remove unneeded yarn compile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires = ["pdm-pep517>=1.0.0"]
 build-backend = "pdm.pep517.api"
 
 [tool.pdm.scripts]
-update-deps = {shell = "git submodule update --init --recursive && cd @account-abstraction && yarn && yarn compile &&  cd ../spec && yarn && yarn build && cd ../@rip7560 && yarn && yarn compile-hardhat"}
+update-deps = {shell = "git submodule update --init --recursive && cd spec && yarn && yarn build && cd ../@rip7560 && yarn && yarn compile-hardhat"}
 update-deps-remote = {shell = "git submodule update --init --recursive --remote && cd @account-abstraction && yarn && yarn compile &&  cd ../spec && yarn && yarn build && cd ../@rip7560 && yarn && yarn compile-hardhat"}
 test = "pytest --tb=short -rA -W ignore::DeprecationWarning --url http://localhost:3000/rpc --entry-point 0x0000000071727De22E5E9d8BAf0edAc6f37da032  --ethereum-node http://127.0.0.1:8545/ tests/single"
 test-rip7560 = "pytest --tb=short -rA -W ignore::DeprecationWarning --url http://localhost:3000/rpc --nonce-manager 0x63f63e798f5F6A934Acf0a3FD1C01f3Fac851fF0  --stake-manager 0x570Aa568b6cf62ff08c6C3a3b3DB1a0438E871Fb --ethereum-node http://127.0.0.1:8545/ tests/rip7560"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from web3.middleware import SignAndSendRawMiddlewareBuilder, ExtraDataToPOAMiddl
 from .types import UserOperation, RPCRequest, CommandLineArgs
 from .utils import (
     assert_ok,
+    compile_contract,
     deploy_and_deposit,
     deploy_contract,
     deploy_wallet_contract,
@@ -78,16 +79,12 @@ def wallet_contract(w3):
 
 @pytest.fixture(scope="session")
 def entrypoint_contract(w3):
-    current_dirname = os.path.dirname(__file__)
-    entrypoint_path = os.path.realpath(
-        current_dirname
-        + "/../@account-abstraction/artifacts/contracts/core/EntryPoint.sol/EntryPoint.json"
+    entrypoint_interface = compile_contract(
+        "@account-abstraction/contracts/interfaces/IEntryPoint"
     )
-    with open(entrypoint_path, encoding="utf-8") as file:
-        entrypoint = json.load(file)
-        return w3.eth.contract(
-            abi=entrypoint["abi"], address=CommandLineArgs.entrypoint
-        )
+    return w3.eth.contract(
+        abi=entrypoint_interface["abi"], address=CommandLineArgs.entrypoint
+    )
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-import json
-import os
 import subprocess
 
 import pytest

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -25,6 +25,9 @@ def compile_contract(contract):
     allow_paths = aa_relpath + "," + rip7560_relpath
     aa_remap = "@account-abstraction=" + aa_relpath
     rip7560_remap = "@rip7560=" + rip7560_relpath
+    if "@account-abstraction" in contract:
+        contracts_dirname = current_dirname + "/../" + contract_subdir + "/"
+
     with open(
         contracts_dirname + contract_name + ".sol", "r", encoding="utf-8"
     ) as contractfile:
@@ -111,7 +114,7 @@ def staked_contract(w3, entrypoint_contract, contract):
     )
     assert int(tx_hash.hex(), 16), "could not stake contract"
     w3.eth.wait_for_transaction_receipt(tx_hash)
-    info = entrypoint_contract.functions.deposits(contract.address).call()
+    info = entrypoint_contract.functions.getDepositInfo(contract.address).call()
     assert info[1], "could not get deposit information"
     return contract
 


### PR DESCRIPTION
no need to rebuild account-abstraction project.
we don't deploy it, and only use IEntryPoint