### PR TITLE
AA-486  rules for CREATE/CREATE2 OP-032, EREP-060,061

### DIFF
--- a/tests/contracts/ValidationRules.sol
+++ b/tests/contracts/ValidationRules.sol
@@ -5,8 +5,21 @@ import "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import "./ITestAccount.sol";
 import "./TestCoin.sol";
 
+
+contract Dummy2 {}
+
 contract Dummy {
-    uint public value = 1;
+    uint public immutable value = 1;
+
+    function create() public returns (uint) {
+        new Dummy2();
+        return 0;
+    }
+
+    function create2() public returns (uint) {
+        new Dummy2{salt: bytes32(uint(0x1))}();
+        return 0;
+    }
 }
 
 contract ValidationRulesStorage is IState {
@@ -90,6 +103,8 @@ library ValidationRules {
         else if (eq(rule, "BALANCE")) return uint160(address(msg.sender).balance);
         else if (eq(rule, "ORIGIN")) return uint160(address(tx.origin));
         else if (eq(rule, "BLOCKHASH")) return uint(blockhash(0));
+        else if (eq(rule, "nested-CREATE")) return new Dummy().create();
+        else if (eq(rule, "nested-CREATE2")) return new Dummy().create2();
         else if (eq(rule, "CREATE")) return new Dummy().value();
         else if (eq(rule, "CREATE2")) return new Dummy{salt : bytes32(uint(0x1))}().value();
         else if (eq(rule, "SELFDESTRUCT")) {
@@ -104,11 +119,11 @@ library ValidationRules {
             return 0;
         }
         else if (eq(rule, "SELFBALANCE")) {
-            uint256 self;
+            uint256 selfb;
             assembly {
-                self :=selfbalance()
+                selfb := selfbalance()
             }
-            return self;
+            return selfb;
         }
         else if (eq(rule, "CALLCODE_undeployed_contract")) {
             assembly {

--- a/tests/single/opbanning/test_create.py
+++ b/tests/single/opbanning/test_create.py
@@ -25,7 +25,7 @@ from tests.utils import (
     deposit_to_undeployed_sender,
     staked_contract,
     to_hex,
-    to_prefixed_hex
+    to_prefixed_hex,
 )
 
 

--- a/tests/single/opbanning/test_create.py
+++ b/tests/single/opbanning/test_create.py
@@ -17,7 +17,6 @@
 from dataclasses import dataclass
 import pytest
 from tests.conftest import assert_ok, deploy_contract
-from tests.force_userop import force_userop
 from tests.types import RPCErrorCode
 from tests.user_operation_erc4337 import UserOperation
 from tests.utils import (

--- a/tests/single/opbanning/test_create.py
+++ b/tests/single/opbanning/test_create.py
@@ -1,0 +1,130 @@
+# create opcode rules
+
+"""
+ **[OP-031]** `CREATE2` is allowed exactly once in the deployment phase and must deploy code for the "sender" address.
+      (Either by the factory itself, or by a utility contract it calls)
+* **[OP-032]** If there is a `factory` (even unstaked), the `sender` contract is allowed to use `CREATE` opcode
+    (That is, only the sender contract itself, not through utility contract)
+* Staked factory creation rules:
+  * **[EREP-060]** If the factory is staked, either the factory itself or the sender may use the CREATE2 and CREATE opcode
+    (the sender is allowed to use the CREATE with unstaked factory, with OP-032)
+  * **[EREP-061]** A staked factory may also use a utility contract that calls the `CREATE`
+
+ if no factory, create/create2 are banned (even for staked entities: they could potentially create another account, and thus
+ "blame" another userop, which we can't link back to this one)
+"""
+
+from dataclasses import asdict, dataclass
+import pytest
+from tests.conftest import assert_ok, deploy_contract
+from tests.types import RPCErrorCode, UserOperation
+from tests.utils import (
+    assert_rpc_error,
+    deposit_to_undeployed_sender,
+    staked_contract,
+    to_hex,
+    to_prefixed_hex,
+)
+
+
+@pytest.mark.parametrize("create_op", ["CREATE", "CREATE2"])
+def test_account_banned_create(rules_account_contract, create_op):
+    userop = UserOperation(
+        sender=rules_account_contract.address, signature=to_prefixed_hex(create_op)
+    )
+    assert_rpc_error(
+        userop.send(),
+        "account uses banned opcode: " + create_op,
+        RPCErrorCode.BANNED_OPCODE,
+    )
+
+
+@pytest.mark.parametrize("create_op", ["CREATE", "CREATE2"])
+def test_paymaster_banned_create(paymaster_contract, wallet_contract, create_op):
+    userop = UserOperation(
+        sender=wallet_contract.address,
+        paymaster=paymaster_contract.address,
+        paymasterData="0x" + to_hex(create_op),
+    )
+    assert_rpc_error(
+        userop.send(),
+        "paymaster uses banned opcode: " + create_op,
+        RPCErrorCode.BANNED_OPCODE,
+    )
+
+
+# OP-031 CREATE2 is allowed exactly once in the deployment phase.
+# (so we check that it fails if it called more than once)
+def test_account_create2_once(w3, factory_contract, entrypoint_contract, banned_op):
+    factoryData = factory_contract.functions.create(
+        123, "CREATE2", entrypoint_contract.address
+    ).build_transaction()["data"]
+    sender = deposit_to_undeployed_sender(
+        w3, entrypoint_contract, factory_contract.address, factoryData
+    )
+    response = UserOperation(
+        sender=sender, factory=factory_contract.address, factoryData=factoryData
+    ).send()
+    assert_rpc_error(
+        response,
+        "factory",
+        RPCErrorCode.BANNED_OPCODE,
+    )
+    assert_rpc_error(
+        response,
+        banned_op,
+        RPCErrorCode.BANNED_OPCODE,
+    )
+
+
+# generic dataclass: can be constructed with any named param.
+#
+@dataclass
+class Case:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def str(self):
+        return ",".join([k + "=" + str(v) for k, v in self.__dict__.items()])
+
+
+op_032_cases = [
+    Case(factory="unstaked", op="CREATE", expect="ok"),
+    Case(factory="unstaked", op="CREATE2", expect="err"),
+    Case(factory="staked", op="CREATE", expect="ok"),
+    Case(factory="staked", op="CREATE2", expect="ok"),
+]
+
+
+@pytest.mark.parametrize("case", op_032_cases, ids=Case.str)
+def test_account_create_with_factory(w3, entrypoint_contract, case):
+    factory = deploy_contract(
+        w3, "TestRulesAccountFactory", ctrparams=[entrypoint_contract.address]
+    )
+    if case.factory == "staked":
+        staked_contract(w3, entrypoint_contract, factory)
+
+    factoryData = factory.functions.create(
+        123, "", entrypoint_contract.address
+    ).build_transaction()["data"]
+
+    sender = deposit_to_undeployed_sender(
+        w3, entrypoint_contract, factory.address, factoryData
+    )
+
+    response = UserOperation(
+        sender=sender,
+        signature=to_prefixed_hex(case.op),
+        factory=factory.address,
+        factoryData=factoryData,
+        verificationGasLimit=hex(5000000),
+    ).send()
+    if case.expect == "ok":
+        assert_ok(response)
+    else:
+        assert_rpc_error(
+            response,
+            "account uses banned opcode: " + case.op,
+            RPCErrorCode.BANNED_OPCODE,
+        )

--- a/tests/single/opbanning/test_op_banning.py
+++ b/tests/single/opbanning/test_op_banning.py
@@ -31,8 +31,8 @@ banned_opcodes = [
     "BALANCE",
     "ORIGIN",
     "BLOCKHASH",
-    "CREATE",
-    "CREATE2",
+    # "CREATE", # TODO: requires special tests (with new parser), see test_create.py for erc-4337
+    # "CREATE2",
     # "SELFDESTRUCT",
 ]
 

--- a/tests/single/opbanning/test_op_banning.py
+++ b/tests/single/opbanning/test_op_banning.py
@@ -4,6 +4,7 @@ See https://github.com/eth-infinitism/bundler
 """
 
 import pytest
+from tests.conftest import entrypoint_contract
 
 from tests.types import RPCErrorCode
 from tests.user_operation_erc4337 import UserOperation
@@ -77,7 +78,7 @@ def test_paymaster_banned_opcode(paymaster_contract, wallet_contract, banned_op)
         sender=wallet_contract.address,
         paymaster=paymaster_contract.address,
         paymasterData="0x" + to_hex(banned_op),
-        paymasterVerificationGasLimit=hex(200000),
+        paymasterVerificationGasLimit=hex(300000),
     ).send()
     assert_rpc_error(
         response,

--- a/tests/transaction_eip_7702.py
+++ b/tests/transaction_eip_7702.py
@@ -28,10 +28,14 @@ class TupleEIP7702:
         if nonce == "0x0":
             nonce = "0x"
 
+        chainId = self.chainId
+        if chainId == "0x0":
+            chainId = "0x"
+
         rlp_encode = bytearray(
             rlp.encode(
                 [
-                    to_bytes(hexstr=self.chainId),
+                    to_bytes(hexstr=chainId),
                     to_bytes(hexstr=self.address),
                     to_bytes(hexstr=nonce),
                 ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -132,7 +132,7 @@ def deploy_state_contract(w3):
 def pack_factory(factory, factory_data):
     if factory is None:
         return "0x"
-    return to_prefixed_hex(factory) + to_hex(factory_data)
+    return hex_concat(factory, factory_data)
 
 
 def pack_uints(high128, low128):
@@ -323,7 +323,9 @@ def to_prefixed_hex(s, byte_count=None):
 
 
 def to_hex(s):
-    if isinstance(s, (int)):
+    if isinstance(s, str) and s.startswith("0x"):
+        return s
+    if isinstance(s, int):
         return hex(s)
     return s.encode().hex()
 


### PR DESCRIPTION
requires new tracer, since we need to check actual caller to CREATe/CREATE2, not only phase