### PR TITLE
cmdline --query-ep

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ jobs:
               http://localhost:3000/rpc
       - run:
           name: "Run pytest"
-          command: pdm run test
+          command: pdm run test --query-ep
   test-rip7560-bundler:
     docker:
       - image: shahafn/go-python-node
@@ -345,7 +345,7 @@ jobs:
             wget --post-data="{\"method\": \"eth_supportedEntryPoints\"}" --retry-connrefused --waitretry=2 --timeout=60 --tries=30 http://localhost:3000/rpc
       - run:
           name: "pytest"
-          command: "pdm run test-eip7702 --log-rpc -v "
+          command: "pdm run test-eip7702 --log-rpc -v --query-ep"
 
 workflows:
   version: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,10 @@ rip7560-build = {shell = "cd @rip7560 && yarn && yarn compile-hardhat" }
 dep-build = {composite = ["spec-build", "rip7560-build"]}
 update-deps = {composite = ["submodule-update", "dep-build"]}
 update-deps-remote = {shell = "git submodule update --init --recursive --remote && cd @account-abstraction && yarn && yarn compile &&  cd ../spec && yarn && yarn build && cd ../@rip7560 && yarn && yarn compile-hardhat"}
-test = "pytest --tb=short -rA -W ignore::DeprecationWarning --url http://localhost:3000/rpc --entry-point 0x0000000071727De22E5E9d8BAf0edAc6f37da032  --ethereum-node http://127.0.0.1:8545/ tests/single"
+test = "pytest --tb=short -rA -W ignore::DeprecationWarning --url http://localhost:3000/rpc --query-ep --ethereum-node http://127.0.0.1:8545/ tests/single"
 test-rip7560 = "pytest --tb=short -rA -W ignore::DeprecationWarning --url http://localhost:3000/rpc --nonce-manager 0x3D45A0363baBA693432f9Cb82c60BE9410A5Fd8f  --stake-manager 0x2F9d2b9Af343dA0288Fc8270354e4c47b63817f3 --ethereum-node http://127.0.0.1:8545/ tests/rip7560"
-test-eip7702 = "pytest --tb=short -rA -W ignore::DeprecationWarning --url http://localhost:3000/rpc --entry-point 0x0000000071727De22E5E9d8BAf0edAc6f37da032 --nonce-manager 0x63f63e798f5F6A934Acf0a3FD1C01f3Fac851fF0  --stake-manager 0x570Aa568b6cf62ff08c6C3a3b3DB1a0438E871Fb --ethereum-node http://127.0.0.1:8545/ tests/eip7702"
-p2ptest = "pytest --tb=short -rA -W ignore::DeprecationWarning --url http://localhost:3000/rpc --entry-point 0x0000000071727De22E5E9d8BAf0edAc6f37da032 --ethereum-node http://127.0.0.1:8545/ tests/p2p"
+test-eip7702 = "pytest --tb=short -rA -W ignore::DeprecationWarning --url http://localhost:3000/rpc --query-ep --nonce-manager 0x63f63e798f5F6A934Acf0a3FD1C01f3Fac851fF0  --stake-manager 0x570Aa568b6cf62ff08c6C3a3b3DB1a0438E871Fb --ethereum-node http://127.0.0.1:8545/ tests/eip7702"
+p2ptest = "pytest --tb=short -rA -W ignore::DeprecationWarning --url http://localhost:3000/rpc --query-ep --ethereum-node http://127.0.0.1:8545/ tests/p2p"
 lint = "pylint tests"
 format = "black tests"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ def pytest_configure(config):
     CommandLineArgs.configure(
         url=config.getoption("--url"),
         entrypoint=config.getoption("--entry-point"),
+        query_ep=config.getoption("--query-ep"),
         nonce_manager=config.getoption("--nonce-manager"),
         stake_manager=config.getoption("--stake-manager"),
         ethereum_node=config.getoption("--ethereum-node"),
@@ -53,6 +54,7 @@ def pytest_addoption(parser):
     parser.addoption("--ethereum-node", action="store")
     parser.addoption("--launcher-script", action="store")
     parser.addoption("--log-rpc", action="store_true", default=False)
+    parser.addoption("--query-ep", action="store_true", default=False)
 
 
 @pytest.fixture(scope="session")

--- a/tests/types.py
+++ b/tests/types.py
@@ -24,6 +24,7 @@ class CommandLineArgs:
         cls,
         url,
         entrypoint,
+        query_ep,
         nonce_manager,
         stake_manager,
         ethereum_node,
@@ -37,6 +38,10 @@ class CommandLineArgs:
         cls.ethereum_node = ethereum_node
         cls.launcher_script = launcher_script
         cls.log_rpc = log_rpc
+        if query_ep:
+            cls.entrypoint = (
+                RPCRequest(method="eth_supportedEntryPoints").send(cls.url).result[0]
+            )
 
 
 @dataclass


### PR DESCRIPTION
--query-ep queries the bundler for its eth_supportedEntryPoint, instead of forcing it to a specific entrypoint.
useful while v0.8 is still unstable, and address gets modified.